### PR TITLE
fix time server

### DIFF
--- a/problems/time_server/solution.js
+++ b/problems/time_server/solution.js
@@ -7,8 +7,8 @@ function zeroFill(i) {
 function now () {
   var d = new Date()
   return d.getFullYear() + '-'
-    + zeroFill(d.getMonth()) + '-'
-    + zeroFill(d.getDay()) + ' '
+    + zeroFill(d.getMonth() + 1) + '-'
+    + zeroFill(d.getDate()) + ' '
     + zeroFill(d.getHours()) + ':'
     + zeroFill(d.getMinutes())
 }


### PR DESCRIPTION
Now returns actual current date. Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
I have no idea how to fix the hints without writing out the solution.
