### PR TITLE
off by one, empty file is not one line

### DIFF
--- a/problems/my_first_io/solution.js
+++ b/problems/my_first_io/solution.js
@@ -7,4 +7,4 @@ console.log(lines)
 // note you can avoid the .toString() by passing 'utf8' as the
 // second argument to readFileSync, then you'll get a String!
 //
-// fs.readFileSync(process.argv[2], 'utf8').split('\n').length
+// fs.readFileSync(process.argv[2], 'utf8').split('\n').length - 1


### PR DESCRIPTION
If the content is empty it must mean 0 lines (matches how wc -l works)
