### PR TITLE
Fixed mismatched port in http file server solution

### DIFF
--- a/problems/http_file_server/solution.js
+++ b/problems/http_file_server/solution.js
@@ -4,4 +4,4 @@ var fs = require('fs')
 var server = http.createServer(function (req, res) {
   fs.createReadStream(process.argv[2]).pipe(res)
 })
-server.listen(8001)
+server.listen(8000)


### PR DESCRIPTION
The problem requires the file server to listen on port 8000 but the listed solution is listening on 8001.
