### PR TITLE
Updated time_server to use first argument as listen port instead of 8000

### DIFF
--- a/problems/http_file_server/problem.txt
+++ b/problems/http_file_server/problem.txt
@@ -1,11 +1,12 @@
 Write an HTTP {bold}server{/bold} that serves the same text file for each request
 it receives.
 
-You will be provided with the location of the file to serve as the
-first command-line argument. You {bold}must{/bold} use the `fs.createReadStream()`
-method to stream the file contents to the response.
+Your server should listen on the port provided by the first argument
+to your program.
 
-Your server should listen on {bold}port 8000{/bold}.
+You will be provided with the location of the file to serve as the
+second command-line argument. You {bold}must{/bold} use the `fs.createReadStream()`
+method to stream the file contents to the response.
 
 ----------------------------------------------------------------------
 HINTS:

--- a/problems/http_file_server/setup.js
+++ b/problems/http_file_server/setup.js
@@ -34,6 +34,8 @@ module.exports = function (run) {
     , trackFile = path.join(os.tmpDir(), 'learnyounode_' + process.pid + '.json')
     , outputA   = through()
     , outputB   = through()
+    , portA = 1024 + Math.floor(Math.random() * 65535)
+    , portB = portA+1
 
   function error (url, out, err) {
     out.write('Error connecting to ' + url + ': ' + err.message)
@@ -41,12 +43,12 @@ module.exports = function (run) {
   }
 
   setTimeout(function () {
-    hyperquest.get('http://localhost:8000')
-      .on('error', error.bind(null, 'http://localhost:8000', outputA))
+    hyperquest.get('http://localhost:' + portA)
+      .on('error', error.bind(null, 'http://localhost:' + portA, outputA))
       .pipe(outputA)
     if (!run) {
-      hyperquest.get('http://localhost:8001')
-        .on('error', error.bind(null, 'http://localhost:8001', outputB))
+      hyperquest.get('http://localhost:' + portB)
+        .on('error', error.bind(null, 'http://localhost:' + portB, outputB))
         .pipe(outputB)
     }
   }, 500)
@@ -54,7 +56,8 @@ module.exports = function (run) {
   fs.writeFileSync(file, bogan({ paragraphs: 1, sentenceMax: 1 }), 'utf8')
 
   return {
-      args        : [ file ]
+      submissionArgs : [portA, file]
+    , solutionArgs : [portB, file]
     , a           : outputA
     , b           : outputB
     , modUseTrack : {

--- a/problems/http_file_server/solution.js
+++ b/problems/http_file_server/solution.js
@@ -2,6 +2,6 @@ var http = require('http')
 var fs = require('fs')
 
 var server = http.createServer(function (req, res) {
-  fs.createReadStream(process.argv[2]).pipe(res)
+  fs.createReadStream(process.argv[3]).pipe(res)
 })
-server.listen(8001)
+server.listen(Number(process.argv[2]))

--- a/problems/http_json_api_server/problem.txt
+++ b/problems/http_json_api_server/problem.txt
@@ -20,7 +20,8 @@ same query string but returns UNIX epoch time under the property
 
   { "unixtime": 1376136615474 }
 
-Your server should listen on {bold}port 8000{/bold}.
+Your server should listen on the port provided by the first argument
+to your program.
 
 ----------------------------------------------------------------------
 HINTS:

--- a/problems/http_json_api_server/setup.js
+++ b/problems/http_json_api_server/setup.js
@@ -36,15 +36,18 @@ function fetch (port) {
 module.exports = function (run) {
   var outputA = through()
     , outputB = through()
+    , portA = 1024 + Math.floor(Math.random() * 65535)
+    , portB = portA+1
 
   setTimeout(function () {
-    fetch(8000).pipe(outputA)
+    fetch(portA).pipe(outputA)
     if (!run)
-      fetch(8001).pipe(outputB)
+      fetch(portB).pipe(outputB)
   }, 500)
 
   return {
-      args : []
+      submissionArgs : [portA]
+    , solutionArgs : [portB]
     , a    : outputA
     , b    : outputB
     , long : true

--- a/problems/http_json_api_server/solution.js
+++ b/problems/http_json_api_server/solution.js
@@ -31,4 +31,4 @@ var server = http.createServer(function (req, res) {
     res.end()
   }
 })
-server.listen(8001)
+server.listen(Number(process.argv[2]))

--- a/problems/http_uppercaserer/problem.txt
+++ b/problems/http_uppercaserer/problem.txt
@@ -2,7 +2,8 @@ Write an HTTP {bold}server{/bold} that receives only POST requests and converts
 incoming POST body characters to upper-case and returns it to the
 client.
 
-Your server should listen on {bold}port 8000{/bold}.
+Your server should listen on the port provided by the first argument
+to your program.
 
 ----------------------------------------------------------------------
 HINTS:

--- a/problems/http_uppercaserer/setup.js
+++ b/problems/http_uppercaserer/setup.js
@@ -5,11 +5,14 @@ const through    = require('through')
         .sort(function () { return 0.5 - Math.random() })
         .slice(0, 10)
 
+
 module.exports = function (run) {
   var outputA = through()
     , outputB = through()
     , inputA  = through().pause()
     , inputB  = through().pause()
+    , portA = 1024 + Math.floor(Math.random() * 65535)
+    , portB = portA+1
     , count   = 0
     , iv
 
@@ -19,12 +22,12 @@ module.exports = function (run) {
   }
 
   setTimeout(function () {
-    inputA.pipe(hyperquest.post('http://localhost:8000')
-      .on('error', error.bind(null, 'http://localhost:8000', outputA)))
+    inputA.pipe(hyperquest.post('http://localhost:' + portA)
+      .on('error', error.bind(null, 'http://localhost:' + portA, outputA)))
         .pipe(outputA)
     if (!run) {
-      inputB.pipe(hyperquest.post('http://localhost:8001')
-        .on('error', error.bind(null, 'http://localhost:8001', outputB)))
+      inputB.pipe(hyperquest.post('http://localhost:' + portB)
+        .on('error', error.bind(null, 'http://localhost:' + portB, outputB)))
           .pipe(outputB)
     }
   }, 500)
@@ -40,9 +43,10 @@ module.exports = function (run) {
       inputB.end()
     }
   }, 50)
-    
+
   return {
-      args: []
+      submissionArgs : [portA]
+    , solutionArgs : [portB]
     , a: duplexer(inputA, outputA)
     , b: duplexer(inputB, outputB)
   }

--- a/problems/http_uppercaserer/solution.js
+++ b/problems/http_uppercaserer/solution.js
@@ -10,4 +10,4 @@ var server = http.createServer(function (req, res) {
   })).pipe(res)
 })
 
-server.listen(8001)
+server.listen(Number(process.argv[2]))

--- a/problems/time_server/problem.txt
+++ b/problems/time_server/problem.txt
@@ -1,7 +1,8 @@
 Write a {bold}TCP time server{/bold}!
 
-Your server should listen to TCP connections on {bold}port 8000{/bold}. For each
-connection you must write the current date & time in the format:
+Your server should listen to TCP connections on the port provided by the
+first argument to your program. For each connection you must write the
+current date & time in the format:
 
   YYYY-MM-DD hh:mm
 

--- a/problems/time_server/setup.js
+++ b/problems/time_server/setup.js
@@ -5,6 +5,8 @@ const through    = require('through')
 module.exports = function (run) {
   var outputA = through()
     , outputB = through()
+    , portA = 1024 + Math.floor(Math.random() * 65535)
+    , portB = portA+1
 
   function error (url, out, err) {
     out.write('Error connecting to ' + url + ': ' + err.message)
@@ -15,19 +17,20 @@ module.exports = function (run) {
     var hqa
       , hqb
 
-    hqa = net.connect(8000)
-    hqa.on('error', error.bind(null, 'localhost:8000', outputA))
+    hqa = net.connect(portA)
+    hqa.on('error', error.bind(null, 'localhost:' + portA, outputA))
       .pipe(outputA)
 
     if (!run) {
-      hqb = net.connect(8001)
-      hqb.on('error', error.bind(null, 'localhost:8001', outputB))
+      hqb = net.connect(portB)
+      hqb.on('error', error.bind(null, 'localhost:' + portB, outputB))
         .pipe(outputB)
     }
   }, 500)
 
   return {
-      args : []
+      submissionArgs : [portA]
+    , solutionArgs : [portB]
     , a    : outputA
     , b    : outputB
   }

--- a/problems/time_server/solution.js
+++ b/problems/time_server/solution.js
@@ -16,4 +16,4 @@ function now () {
 var server = net.createServer(function (socket) {
   socket.end(now() + '\n')
 })
-server.listen(8001)
+server.listen(Number(process.argv[2]))


### PR DESCRIPTION
This is in response to #14 and nodeschool/discussions#30 (also lots of others). This should ensure that the solution displayed more closely matches the student's submission.

This changes the time_server lesson to ask the student to use the port provided by the first argument.
- updated setup.js to use separate ports via submissionArgs/solutionArgs.
- updated solution.js to listen on process.argv[2]
- updated problem.txt to tell the student to use first argument as the port and added a hint regarding portNumber.

Using program arguments matches the patterns in previous lessons completed by the student, which should be less confusing to them than using process.env.PORT (as suggested in discussion). Maybe using proces.env could be introduced in a separate lesson? :smiley:
