### PR TITLE
Fix dangling-callback in "early return" example code

### DIFF
--- a/problems/make_it_modular/problem.txt
+++ b/problems/make_it_modular/problem.txt
@@ -50,11 +50,13 @@ function you can call!
 Also keep in mind that it is idiomatic to check for errors and do early-returns
 within callback functions:
 
-  foo(function (err, data) {
-    if (err)
-      return callback(err)
+  function bar (callback) {
+    foo(function (err, data) {
+      if (err)
+        return callback(err) // early return
 
-    ... // continue when no-error
-  })
+      ... // continue when no-error
+    })
+  }
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
This came up [here](https://github.com/nodeschool/discussions/issues/115#issuecomment-30554909), raised by @mikeal.

I'm a little weary of making this example more complex than it is because it's only trying to describe a very simple concept. Could I get some feedback from other maintainers about this before it gets merged (or not merged) please?
