### PR TITLE
Add test case from make_it_modular to filtered_ls

### DIFF
--- a/problems/filtered_ls/setup.js
+++ b/problems/filtered_ls/setup.js
@@ -15,6 +15,7 @@ const fs        = require('fs')
         , 'w00t.dat'
         , 'w00t.txt'
         , 'wrrrrongdat'
+        , 'dat'
       ]
 
 module.exports = function () {


### PR DESCRIPTION
Here is a (really) small PR.

I was struggling to pass the `make_it_modular` challenge because it states that _"This problem is the same as the previous but introduces the concept of modules."_ and my program had a bug which was not reported in `filtered_ls`. I just added the right test case (one more file named like the tested file extension, `dat`) to make it fail in `filtered_ls` too.

Here is an extract of the solution that was passing in `filtered_ls` but not in `make_it_modular`: 

```
files.forEach(function (file) {
  if (file.split('.').pop() === extension) {
    console.log(file);
  }
});
```

If `file === extension`, then `file.split('.').pop() === extension` and this solution fails.

It failed only in `make_it_modular` because the test cases where:

```
files = [
      'learnyounode.dat'
    , 'learnyounode.txt'
    , 'learnyounode.sql'
    , 'api.html'
    , 'README.md'
    , 'CHANGELOG.md'
    , 'LICENCE.md'
    , 'md'
    , 'data.json'
    , 'data.dat'
    , 'words.dat'
    , 'w00t.dat'
    , 'w00t.txt'
    , 'wrrrrongdat'
  ]
```
