### PR TITLE
Add missing text to my_first_io problem description.

### DIFF
--- a/problems/my_first_io/problem.txt
+++ b/problems/my_first_io/problem.txt
@@ -35,7 +35,8 @@ Documentation on `Buffer`s can be found by pointing your browser here:
 
 If you're looking for an easy way to count the number of newlines in a
 string, recall that a JavaScript `String` can be `.split()` into an
-array of substrings and that '\n'. Using this method you'll end up
-with an array that has one more element than the number of newlines.
+array of substrings based on a specified separator and that '\n' is the
+newline character. Using this method you'll end up with an array that has
+one more element than the number of newlines.
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
The problem description for my_first_io was missing the end of a sentence. I added what seemed to be some reasonable verbiage to complete and clarify.
