### PR TITLE
Juggling Async solution: Output err instead of data if err is passed

### DIFF
--- a/exercises/juggling_async/solution/solution.js
+++ b/exercises/juggling_async/solution/solution.js
@@ -12,7 +12,7 @@ function httpGet (index) {
   http.get(process.argv[2 + index], function (response) {
     response.pipe(bl(function (err, data) {
       if (err)
-        return console.error(data)
+        return console.error(err)
 
       results[index] = data.toString()
       count++


### PR DESCRIPTION
I think there's a slight typo in the Juggling Async solution. Seemed faster to fork than to just open an issue :) Thanks for the awesome learning resource!
