### PR TITLE
unify on "program.js" instead of "myprogram.js"

### DIFF
--- a/exercises/baby_steps/problem.md
+++ b/exercises/baby_steps/problem.md
@@ -11,10 +11,10 @@ To get started, write a program that simply contains:
 console.log(process.argv)
 ```
 
-Run it with `node myprogram.js` and some numbers as arguments. e.g:
+Run it with `node program.js` and some numbers as arguments. e.g:
 
 ```sh
-$ node myprogram.js 1 2 3
+$ node program.js 1 2 3
 ```
 
 In which case the output would be an array looking something like:

--- a/exercises/hello_world/problem.md
+++ b/exercises/hello_world/problem.md
@@ -7,7 +7,7 @@ To make Node.js program, create a new file with a `.js` extension and start writ
 `node` command. e.g.:
 
 ```sh
-$ node myprogram.js
+$ node program.js
 ```
 
 You can write to the console in the same way as in the browser:
@@ -19,7 +19,7 @@ console.log("text")
 When you are done, you must run:
 
 ```sh
-$ {appname} verify myprogram.js
+$ {appname} verify program.js
 ```
 
 to proceed. Your program will be tested, a report will be generated, and the lesson will be marked 'completed' if you are successful.


### PR DESCRIPTION
In the Hello World and Baby Steps lessons, the instructions say to create the program as `myprogram.js`, while the command given at the bottom uses `program.js`. This could be confusing for a beginner copy/pasting the command. Since `program.js` is used in stream-adventure, it makes sense to unify on that.
