### PR TITLE
correct JSON.stringify() typo

### DIFF
--- a/exercises/http_json_api_server/problem.md
+++ b/exercises/http_json_api_server/problem.md
@@ -38,7 +38,7 @@ $ node -pe "require('url').parse('/test?q=1', true)"
 Documentation on the `url` module can be found by pointing your browser here:
   {rootdir:/node_apidoc/url.html}
   
-Your response should be in a JSON string format. Look at `JSON#stringify()` for more information.
+Your response should be in a JSON string format. Look at `JSON.stringify()` for more information.
 
 You should also be a good web citizen and set the Content-Type properly:
 


### PR DESCRIPTION
This just corrects `JSON#stringify()` to read `JSON.stringify()`.

(Noticed this while working through the _last_ lesson. Whoo!)
