### PR TITLE
Fix link format to open correct URLs in iTerm - Exercise 8

### DIFF
--- a/exercises/http_collect/problem.md
+++ b/exercises/http_collect/problem.md
@@ -11,8 +11,8 @@ There are two approaches you can take to this problem:
 
 **2)** Use a third-party package to abstract the difficulties involved in collecting an entire stream of data. Two different packages provide a useful API for solving this problem (there are likely more!): `bl` (Buffer List) and `concat-stream`; take your pick!
 
-  http://npm.im/bl
-  http://npm.im/concat-stream
+  <http://npm.im/bl>
+  <http://npm.im/concat-stream>
 
 To install a Node package, use the Node Package Manager `npm`. Simply type:
 


### PR DESCRIPTION
Using iTerm and clicking on the links, iTerm incorrectly opens the URLs. Oh funky, it's opening the markdown for the URLs! Ex:

![bad url](https://i.cloudup.com/9KswbNy4WZ.png)

Currently opening links in regular old terminal works; however with this formatting added, they now open fine with both iTerm and terminal. Let me know if this makes sense.
