### PR TITLE
Add check for `ext` where `.ext` is expected

### DIFF
--- a/exercises/make_it_modular/verify.js
+++ b/exercises/make_it_modular/verify.js
@@ -131,7 +131,7 @@ function validateModule (modFile, callback) {
         //---- Check for `ext` instead of `.ext`
         if (noDotExp.length === list.length) {
           return modFileError(
-            'seems to match incorrect input "ext" instead of ".ext"'
+            'may be matching "ext" instead of ".ext"'
           )
         }
 


### PR DESCRIPTION
Give more helpful error message for common misstake.
close #127, close #86, close nodeschool/discussions#64
