### PR TITLE
Fix error message

### DIFF
--- a/exercises/http_json_api_server/exercise.js
+++ b/exercises/http_json_api_server/exercise.js
@@ -64,7 +64,7 @@ function query (mode) {
   var exercise = this
 
   function verify (port, stream) {
-    function error (port, err) {
+    function error (err) {
       exercise.emit(
           'fail'
         , 'Error connecting to http://localhost:' + port + ': ' + err.message


### PR DESCRIPTION
Bugfix: Error handling function argument.
Now takes only the error argument, as intended. Emit the error
instead of throwing on `err.message` access.
Fixes #93
