### PR TITLE
Instructions discrepancy

### DIFF
--- a/exercises/my_first_io/problem.md
+++ b/exercises/my_first_io/problem.md
@@ -1,6 +1,6 @@
 Write a program that uses a single **synchronous** filesystem operation to read a file and print the number of newlines it contains to the console (stdout), similar to running `cat file | wc -l`.
 
-The full path to the file to read will be provided as the first command-line argument.
+The full path to the file to read will be provided as the third command-line argument.
 
 ----------------------------------------------------------------------
 ## HINTS


### PR DESCRIPTION
Instructions currently indicate that the file to be read will be provided as the first command-line argument, when in fact upon running it is the third.
