### PR TITLE
explicit check for '.' prefix usage

### DIFF
--- a/exercises/make_it_modular/verify.js
+++ b/exercises/make_it_modular/verify.js
@@ -18,7 +18,7 @@ function validateModule (modFile, callback) {
   try {
     mod = require(modFile)
   } catch (e) {
-    exercise.emit('fail', __('fail.loadError', {message: e.message, path: path.basename(modFile)}))
+    exercise.emit('fail', __('fail.loadError', { message: e.message, path: path.basename(modFile) }))
     return callback(null, false)
   }
 
@@ -28,21 +28,25 @@ function validateModule (modFile, callback) {
   }
 
   function modFileError (txt) {
-    exercise.emit('fail', __('fail.mod._base', {path: path.basename(modFile), message: txt}))
+    exercise.emit('fail', __('fail.mod._base', { path: path.basename(modFile), message: txt }))
     callback (null, false)
   }
 
   //---- Check that our module file is `module.exports = function () {}`
 
   if (typeof mod != 'function')
-    return modFileError(__('fail.mod.no_export', {method: chalk.bold(__('fail.mod.singleFunction'))}))
+    return modFileError(__('fail.mod.no_export', { method: chalk.bold(__('fail.mod.singleFunction')) }))
 
   exercise.emit('pass', __('pass.singleFunction'))
 
   //---- Check that the function exported takes 3 arguments
 
-  if (mod.length < 3)
-    return modFileError(__n('fail.mod.arguments', mod.length, {three: chalk.bold(__('fail.mod.arguments_three')), callback: chalk.bold(__('fail.mod.arguments_callback'))}))
+  if (mod.length < 3) {
+    return modFileError(
+        __n('fail.mod.arguments', mod.length, { three: chalk.bold(__('fail.mod.arguments_three'))
+      , callback: chalk.bold(__('fail.mod.arguments_callback')) })
+    )
+  }
 
   exercise.emit('pass', __n('pass.arguments', mod.length))
 
@@ -87,40 +91,52 @@ function validateModule (modFile, callback) {
     fs.readdir = fs.$readdir
 
     callbackUsed = false
+
+    // a special follow-up for when we detect they are not passing back
+    // the right number of elements--the most common case is that they are
+    // sending in the '.'-prefixed value
+    function checkWithDot () {
+      mod(dir, '.dat', function (err, list) {
+        var notexp = files.filter(function (f) { return (/\.dat$/).test(f) })
+        if (list.length == notexp.length)
+          return modFileError(__('fail.mod.dont_use_dot'))
+
+        exercise.emit('pass', __('pass.dont_use_dot'))
+        // else ... no idea what went wrong here!
+        modFileError(__('fail.mod.array_wrong_size'))
+      })
+    }
+
     try {
       mod(dir, 'md', function (err, list) {
-        if (err) {
-          return modFileError(__('fail.mod.callback_error', {error: util.inspect(err)}))
-        }
+        if (err)
+          return modFileError(__('fail.mod.callback_error', { error: util.inspect(err) }))
 
         //---- Check that we got the correct number of elements
-        if (arguments.length < 2) {
+        if (arguments.length < 2)
           return modFileError(__n('fail.mod.callback_arguments', arguments.length))
-        }
 
         exercise.emit('pass', __('pass.callback_arguments'))
 
         //---- Check that we got an Array as the second argument
-        if (!Array.isArray(list)) {
+        if (!Array.isArray(list))
           return modFileError(__('fail.mod.missing_array_argument'))
-        }
 
         exercise.emit('pass', __('pass.array_argument'))
 
-        var exp = files.filter(function (f) { return (/\.md$/).test(f) })
-          , noDotExp = files.filter(function(f) { return (/md$/).test(f) })
+        var exp      = files.filter(function (f) { return (/\.md$/).test(f) })
+          , noDotExp = files.filter(function (f) { return (/md$/).test(f) })
           , i
 
         //---- Check for `ext` instead of `.ext`
-        if (noDotExp.length === list.length) {
+        if (noDotExp.length === list.length)
           return modFileError(__('fail.mod.dotExt'))
-        }
 
         //---- Check that we got the expected number of elements in the Array
-        if (exp.length !== list.length) {
-          return modFileError(__('fail.mod.array_wrong_size'))
-        }
+        if (exp.length !== list.length)
+          return checkWithDot()
 
+        exercise.emit('pass', __('pass.dont_use_dot'))
         exercise.emit('pass', __('pass.array_size'))
 
         callbackUsed = true
@@ -129,9 +145,8 @@ function validateModule (modFile, callback) {
         exp.sort()
         list.sort()
         for (i = 0; i < exp.length; i++) {
-          if (list[i] !== exp[i]) {
+          if (list[i] !== exp[i])
             return modFileError(__('fail.mod.array_comparison'))
-          }
         }
 
         exercise.emit('pass', __('pass.final'))
@@ -140,7 +155,7 @@ function validateModule (modFile, callback) {
         callback()
       })
     } catch (e) {
-      return modFileError(__('fail.mod.unexpected', {error: util.inspect(e)}))
+      return modFileError(__('fail.mod.unexpected', { error: util.inspect(e) }))
     }
 
     setTimeout(function () {
@@ -187,10 +202,10 @@ function verify (callback) {
   Object.keys(this.wrapData.fsCalls).forEach(function (m) {
     if (/Sync$/.test(m)) {
       usedSync = true
-      this.emit('fail', this.__('fail.sync', {method: 'fs.' + m + '()'}))
+      this.emit('fail', this.__('fail.sync', { method: 'fs.' + m + '()' }))
     } else {
       usedAsync = true
-      this.emit('pass', this.__('pass.async', {method: 'fs.' + m + '()'}))
+      this.emit('pass', this.__('pass.async', { method: 'fs.' + m + '()' }))
     }
   }.bind(this))
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -34,6 +34,7 @@
           "missing_callback": "did not call the callback argument after an error from fs.readdir()",
           "missing_error": "does not appear to pass back an error received from `fs.readdir()`.\n  Use the following idiomatic Node.js pattern inside your callback to `fs.readdir()`:\n\tif (err)\n\t  return callback(err)",
           "callback_arguments": "did not return two arguments on the callback function (expected `null` and an Array of filenames)",
+          "dont_use_dot": "appears to be expecting a '.'-prefixed extension, it should receive the second command-line argument without the added '.'",
           "array_wrong_size": "did not return an Array with the correct number of elements as the second argument of the callback",
           "dotExt": "may be matching \"ext\" instead of \".ext\"",
           "array_comparison": "did not return the correct list of files as the second argument of the callback",
@@ -50,6 +51,7 @@
         "callback": "Additional module file handles callback argument",
         "callback_arguments": "Additional module file returned two arguments on the callback function",
         "array_argument": "Additional module file returned correct number of elements as the second argument of the callback",
+        "dont_use_dot": "Additional module file correctly handles '.'-prefixed extension",
         "array_size": "Additional module file returned correct number of elements as the second argument of the callback",
         "final": "Additional module file returned correct list of files as the second argument of the callback"
       }


### PR DESCRIPTION
Potential fix for #222 & nodeschool/discussions#64 & countless other confused issues filed about the _"did not return an Array with the correct number of elements as the second argument of the callback"_ error when all they are doing wrong is passing in the extension with a `.` prefixed when they were asked not to.

Failure looks like this:

![screenshot from 2015-02-16 16 04 23](https://cloud.githubusercontent.com/assets/495647/6207450/0080bb0e-b5f6-11e4-9402-368bb0dbe253.png)

Collaborators, if I could have your help to review this, at least:

* Comment on the wording I've used here if you have suggestions for improvements
* Start translating the new strings!

Also included some minor style fixes for stuff I keep stumbling across that crept in with the i18n changes.