### PR TITLE
Add browser guide

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "Leonardo Nascimento <leo386386@gmail.com> (https://github.com/leonardo386)",
     "Christophe Porteneuve <christophe@delicious-insights.com> (https://www.js-attitude.fr/node-js/)"
   ],
+  "scripts": {
+    "html": "workshopper-browser-guide",
+    "guide": "./publishguide.sh"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/rvagg/learnyounode.git"
@@ -41,6 +45,7 @@
     "through2": "~0.6.3",
     "through2-map": "~1.4.0",
     "workshopper": "~2.3.1",
+    "workshopper-browser-guide": "^1.0.0",
     "workshopper-exercise": "~2.3.0",
     "workshopper-wrappedexec": "~0.1.1"
   },

--- a/publishguide.sh
+++ b/publishguide.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+npm run html
+git add guide
+git commit -m 'update guide'
+
+git checkout gh-pages &&
+git merge -s subtree master && 
+git push origin gh-pages && 
+git checkout master


### PR DESCRIPTION
Hey,

I created a module called [workshopper-browser-guide](https://github.com/finnp/workshopper-browser-guide) for creating git-it-style html guides from the exercises.

This PR adds this module and a few scripts for creating the html versions as well as publishing it to GitHub pages. This means that for every exercise change, you will need to run:  `npm run guide`

I published an example for this over here: http://www.finnpauls.de/learnyounode/guide/

What do you think?

Best,
Finn
