### PR TITLE
Fix English message for 'array_argument'

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -49,7 +49,7 @@
         "error": "Additional module file handles errors properly",
         "callback": "Additional module file handles callback argument",
         "callback_arguments": "Additional module file returned two arguments on the callback function",
-        "array_argument": "Additional module file returned correct number of elements as the second argument of the callback",
+        "array_argument": "Additional module file returned an Array as the second argument of the callback",
         "array_size": "Additional module file returned correct number of elements as the second argument of the callback",
         "final": "Additional module file returned correct list of files as the second argument of the callback"
       }


### PR DESCRIPTION
Previously, the text for array_argument and array_size
were identical, which was incorrect.

Now, array_argument correctly indicates that the value
is of the correct type (Array) and array_size indicates
that the value has the correct number of elements.

Partially addresses issue #296