### PR TITLE
Fixes wrong spanish translations

### DIFF
--- a/exercises/make_it_modular/problem.es.md
+++ b/exercises/make_it_modular/problem.es.md
@@ -6,7 +6,7 @@ Deberás escribir un archivo *modular* para hacer la tarea. Dicho módulo debe *
 
 En Node, los callbacks suelen tener una firma convencional de tener (error, data). Esto implica que si hay un error el primer parámetro devuelve el error sino viene `null` y el segundo parámetro son los datos. Para este ejercicio los datos a devolver es la lista de archivos en forma de Array. Si occurre un error, por ejemplo en la llamada a `fs.readdir()`, el callback debe llamarse con dicho error.
 
-Para completar el ejercicio **debes** imprimir desde el módulo y no desde el programa principal. En caso de que el módulo devuelva un error el programa deberá imprimir en consola la información del error.
+Para completar el ejercicio **no debes** imprimir desde el módulo, sólo desde el programa principal. En caso de que el módulo devuelva un error a tu programa principal, simplemente compruébalo y escribe un mensaje informativo en consola.
 
 El módulo debe cumplir el siguiente contrato:
 1. Exportar una función que reciba los parámetros mencionados.

--- a/exercises/my_first_async_io/problem.es.md
+++ b/exercises/my_first_async_io/problem.es.md
@@ -1,4 +1,4 @@
-Escribe un programa que use operación de sistema de archivos asíncrona para leer un archivo e imprimir en consola el número de líneas (terminadas en '\n') que contiene. Similar a  ejecutar `cat file | wc -l`.
+Escribe un programa que use operación de sistema de archivos asíncrona para leer un archivo e imprimir en consola el número de saltos de línea ('\n') que contiene. Similar a  ejecutar `cat file | wc -l`.
 
 El programa recibirá la ruta al archivo como único argumento.
 

--- a/exercises/my_first_io/problem.es.md
+++ b/exercises/my_first_io/problem.es.md
@@ -1,4 +1,4 @@
-Escribe un programa que, usando una llamada síncrona al sistema de archivos, lea un archivo recibido por argumento e imprima a consola la cantidad de líneas nuevas (\n) que contiene. Similar a ejecutar `cat file | wc -l`.
+Escribe un programa que, usando una llamada síncrona al sistema de archivos, lea un archivo recibido por argumento e imprima a consola la cantidad de saltos de línea ('\n') que contiene. Similar a ejecutar `cat file | wc -l`.
 
 El programa recibirá la ruta al archivo como único argumento.
 
@@ -23,6 +23,6 @@ Los objetos `Buffer` de Node son una representación eficiente de Arrays de dato
 Puedes leer la documentación del objeto `Buffer` en:
   {rootdir:/node_apidoc/buffer.html}
 
-Una forma sencilla de contar los números de línea es dividir el String con la función `split`, nativa de JavaScript, usando el carácter de nueva línea ('\n'). Ten en cuenta que el archivo puede no tener '\n' al final por lo que la lista resultante puede tener 1 elemento más que líneas en el archivo.
+Si buscas una forma sencilla de contar el número de saltos de línea en un string, piensa que puedes convertir un `String` de Javascript en un array de substrings usando `.split()`, y que puedes usar '\n' como delimitador. Nótese que el fichero de test no tiene ningún salto de línea ('\n') al final de la última línea, con lo que al usar este método acabarás obteniendo un array que tiene un elemento más que el número de saltos de línea.
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
Today (23 May) I attended as tutor to the International NodeSchool Day in Seville, Spain.
There I detected that some of the spanish translations for some of the exercises where misleading, or even had the opposite translation for some parts of the text.

This PR includes fixes for the ones we detected today. I'll keep checking the rest of the translations, though!