### PR TITLE
bugfix.  checked wrong file, so no solution will pass

### DIFF
--- a/exercises/make_it_modular/verify.js
+++ b/exercises/make_it_modular/verify.js
@@ -192,7 +192,7 @@ function verifyModuleUsed (callback) {
     return callback(null, false)
   }
 
-  validateModule.call(this, required[0], callback)
+  validateModule.call(this, required[1], callback)
 }
 
 function verify (callback) {


### PR DESCRIPTION
this bug confused a lot people.  
see [google "learnyounode make it modular does not export a single function"](https://www.google.co.jp/search?q=learnyounode+make+it+modular+does+not+export+a+single+function&oq=learnyounode+make+it+modular+does+not+export+a+single+function&aqs=chrome..69i57.264j0j7&sourceid=chrome&es_sm=91&ie=UTF-8)
