### PR TITLE
Add reference to the input file in problem.md

### DIFF
--- a/exercises/my_first_io/problem.md
+++ b/exercises/my_first_io/problem.md
@@ -1,6 +1,6 @@
 Write a program that uses a single **synchronous** filesystem operation to read a file and print the number of newlines (\n) it contains to the console (stdout), similar to running `cat file | wc -l`.
 
-The full path to the file to read will be provided as the first command-line argument. You do not need to make your own test file. 
+The full path to the file to read will be provided as the first command-line argument (i.e., process.argv[2]). You do not need to make your own test file. 
 
 ----------------------------------------------------------------------
 ## HINTS


### PR DESCRIPTION
When I read that the input file is the first command line argument, I mistakenly thought it was process.argv[0].  After several unsuccessful submissions, I decided to console log process.argv.  Only then that I realized the input file is process.argv[2].  Seeing that this will probably hinder other newbies like myself, I added this hint to the problem.md.