### PR TITLE
Update workshopper-exercise dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "through": "~2.3.6",
     "through2": "~0.6.3",
     "through2-map": "~1.4.0",
-    "workshopper": "~2.7.0",
-    "workshopper-exercise": "~2.4.0",
+    "workshopper": "^2.7.0",
+    "workshopper-exercise": "^2.4.0",
     "workshopper-wrappedexec": "~0.1.1"
   },
   "bin": {


### PR DESCRIPTION
It use `~2.4.0` card, that means it match only `~2.4.x` versions of `workshopper-exercise` in `package.json`. That's a problem because I've made Ukrainian translation for `workshopper-exercise` and it was released as `2.5.0` version. 

In this pull request, I've changed `~` to `^`, so it will match with `2.x.x` versions.

BTW: [stackoverflow link](http://stackoverflow.com/questions/22343224/difference-between-tilde-and-caret-in-package-json)