### PR TITLE
Clarify time server instructions.

### DIFF
--- a/exercises/time_server/problem.md
+++ b/exercises/time_server/problem.md
@@ -12,6 +12,8 @@ followed by a **newline** character. Month, day, hour and minute must be *zero-f
 "2013-07-06 17:42"
 ```
 
+After sending the string, close the connection.
+
 ----------------------------------------------------------------------
 ## HINTS
 


### PR DESCRIPTION
Clarify that the time server should close the connection immediately after
sending the time.