### PR TITLE
verification of content-type and status code for http file server exercise

### DIFF
--- a/exercises/http_file_server/exercise.js
+++ b/exercises/http_file_server/exercise.js
@@ -91,6 +91,22 @@ function query (mode) {
           , exercise.__('fail.connection', {address: url, message: err.message})
         )
       })
+      .on('response', function(res) {
+        if(res.statusCode != 200) {
+          exercise.emit(
+            'fail',
+            exercise.__('fail.status_code', {status: res.statusCode}))
+        }
+        if(res.headers['content-type'] === undefined) {
+          exercise.emit(
+            'fail',
+            exercise.__('fail.missing_content_type'))
+        } else if(res.headers['content-type'] != 'text/plain') {
+          exercise.emit(
+            'fail',
+            exercise.__('fail.content_type', {header: res.headers['content-type']}))
+        }
+      })
     req.pipe(stream)
     setTimeout(function () {
       stream.unpipe(req)

--- a/exercises/http_file_server/problem.md
+++ b/exercises/http_file_server/problem.md
@@ -17,6 +17,8 @@ function callback (request, response) { /* ... */ }
 
 Where the two arguments are objects representing the HTTP request and the corresponding response for this request. `request` is used to fetch properties, such as the header and query-string from the request while `response` is for sending data to the client, both headers and body.
 
+When sending the HTTP response, it is important to specify what kind of data you're sending back. This is declared in the 'Content-Type' header. For this exercise we'll be sending plain text, so the content type will be 'text/plain'. Look at `response.writeHead()` in the `http` module to learn how to do this.
+
 Both `request` and `response` are also Node streams! Which means that you can use the streaming abstractions to send and receive data if they suit your use-case.
 
 `http.createServer()` also returns an instance of your `server`. You must call `server.listen(portNumber)` to start listening on a particular port.

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -56,7 +56,10 @@
     },
     "HTTP FILE SERVER": {
       "fail": {
-        "no_createReadStream": "Used fs method other than fs.createReadStream(): {{{method}}}"
+        "no_createReadStream": "Used fs method other than fs.createReadStream(): {{{method}}}",
+        "status_code": "Status code of HTTP response was incorrect: {{{status}}}",
+        "missing_content_type": "`Content-Type` header was not found in the response",
+        "content_type": "`Content-Type` header was not `text/plain`: {{{header}}}"
       }
     }
   }


### PR DESCRIPTION
Clarified that setting the content-type and status code are now required. Added verification to exercise.js
Fixes #348  