### PR TITLE
MAKE IT MODULAR: Allow for the optional readdir parameter

### DIFF
--- a/exercises/make_it_modular/verify.js
+++ b/exercises/make_it_modular/verify.js
@@ -46,11 +46,15 @@ function validateModule (modFile, callback) {
 
   exercise.emit('pass', __n('pass.arguments', mod.length))
 
-  //---- Mock `fs.readdir` and check that an error bubbles back up through the cb 
+  //---- Mock `fs.readdir` and check that an error bubbles back up through the cb
 
   fs.$readdir = fs.readdir
-  fs.readdir = function (dir, callback) {
-    callback(error)
+  fs.readdir = function (dir, encodingOrCallback, callback) {
+    if (typeof callback === 'function') {
+      callback(error)
+    } else if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback(error)
+    }
   }
 
   function noerr () {


### PR DESCRIPTION
Updated the mock `fs.readdir` to allow for the optional encoding parameter so the following will not fail:

``` js
fs.readdir(dir, 'utf8', (err, list) => {...})
```

Also accidentally updated some white space. Deals with https://github.com/workshopper/learnyounode/issues/436
