### PR TITLE
FIX: Make It Modular - Allow optional encoding parameter

### DIFF
--- a/exercises/make_it_modular/verify.js
+++ b/exercises/make_it_modular/verify.js
@@ -50,7 +50,8 @@ function validateModule (modFile, callback) {
   // ---- Mock `fs.readdir` and check that an error bubbles back up through the cb
 
   fs.$readdir = fs.readdir
-  fs.readdir = function (dir, callback) {
+  fs.readdir = function (dir, optionalEncoding, callback) {
+    callback = callback || optionalEncoding 
     callback(error)
   }
 

--- a/exercises/make_it_modular/verify.js
+++ b/exercises/make_it_modular/verify.js
@@ -51,7 +51,7 @@ function validateModule (modFile, callback) {
 
   fs.$readdir = fs.readdir
   fs.readdir = function (dir, optionalEncoding, callback) {
-    callback = callback || optionalEncoding 
+    callback = callback || optionalEncoding
     callback(error)
   }
 

--- a/test/make_it_modular/module_valid_02.js
+++ b/test/make_it_modular/module_valid_02.js
@@ -1,0 +1,16 @@
+var fs = require('fs')
+var path = require('path')
+
+// call readdir with optional encoding parameter
+module.exports = function (directory, filter, callback) {
+  filter = '.' + filter
+  fs.readdir(directory, 'utf8', function (error, list) {
+    if (error) {
+      return callback(error)
+    }
+
+    callback(null, list.filter(function (entry) {
+      return path.extname(entry) === filter
+    }))
+  })
+}

--- a/test/make_it_modular/valid_02.js
+++ b/test/make_it_modular/valid_02.js
@@ -1,0 +1,9 @@
+require('./module_valid_02')(process.argv[2], process.argv[3], function (error, list) {
+  if (error) {
+    return console.log(error)
+  }
+
+  list.forEach(function (entry) {
+    console.log(entry)
+  })
+})


### PR DESCRIPTION
This resolves https://github.com/nodeschool/discussions/issues/1999. Searching through the history I believe a few other folks have run up against this as well. 

This fixes a false negative users are receiving on the Make It Modular course when calling `fs.readdir` with its optional encoding parameter. Any solution that passes the optional parameter will erroneously fail, because the workshopper assumes that the second parameter will always be the callback:

```javascript
fs.readdir(filePath, 'utf8', function(err, files) {});
```

This PR also includes a test case to validate that the false negative is resolved. 
