### PR TITLE
Simplify scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,9 +80,9 @@
     "workshopper-adventure-test": "^1.0.4"
   },
   "scripts": {
-    "lint": "./node_modules/.bin/standard",
-    "test": "npm run lint && ./node_modules/.bin/workshopper-adventure-test",
-    "release": "./node_modules/.bin/standard-version"
+    "lint": "standard",
+    "test": "npm run lint && workshopper-adventure-test",
+    "release": "standard-version"
   },
   "bin": {
     "learnyounode": "./bin/learnyounode"


### PR DESCRIPTION
Due to how the [path](https://docs.npmjs.com/misc/scripts#path) works in npm, it's not necessary to specify the whole path to `node_modules`.