### PR TITLE
Node 4 no longer supported in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - '0.12'
-  - '4.0'
   - '5.0'
   - '6'
   - '7'


### PR DESCRIPTION
Stop support for very old versions of node