### PR TITLE
(WIP) FIX: Failing Build for Node v5

### DIFF
--- a/test/make_it_modular/valid_02.js
+++ b/test/make_it_modular/valid_02.js
@@ -1,4 +1,13 @@
-require('./module_valid_02')(process.argv[2], process.argv[3], function (error, list) {
+// use optional encoding parameter solution if current version of node supports it,
+// otherwise fallback to the original version
+var nodeMajorVersion = parseInt(process.version[1])
+if (nodeMajorVersion >= 6) {
+  require('./module_valid_02')(process.argv[2], process.argv[3], handleOutput)
+} else {
+  require('./module_valid_01')(process.argv[2], process.argv[3], handleOutput)
+}
+
+function handleOutput (error, list) {
   if (error) {
     return console.log(error)
   }
@@ -6,4 +15,5 @@ require('./module_valid_02')(process.argv[2], process.argv[3], function (error, 
   list.forEach(function (entry) {
     console.log(entry)
   })
-})
+}
+

--- a/test/make_it_modular/valid_02.js
+++ b/test/make_it_modular/valid_02.js
@@ -16,4 +16,3 @@ function handleOutput (error, list) {
     console.log(entry)
   })
 }
-


### PR DESCRIPTION
Thanks @AnshulMalik for bringing this to my attention. #502 caused the build to fail for Node v5. The build is failing on a test case that verifies the encoding parameter's behavior. This is because the optional encoding parameter for `fs.readdir` was not present in v5. 

The fix proposed here is to make the execution of the test conditional depending on the current version of Node and whether it supports the encoding parameter. It is definitely a hack, but could not think of another way to solve this. Anyone have another approach in mind?