### PR TITLE
Fix method name confusion on the exercise HINT

### DIFF
--- a/exercises/my_first_async_io/problem.md
+++ b/exercises/my_first_async_io/problem.md
@@ -15,7 +15,7 @@ Remember that idiomatic Node.js callbacks normally have the signature:
 function callback (err, data) { /* ... */ }
 ```
 
-so you can check if an error occurred by checking whether the first argument is truthy. If there is no error, you should have your `Buffer` object as the second argument. As with `readFileSync()`, you can supply 'utf8' as the second argument and put the callback as the third argument and you will get a `String` instead of a `Buffer`.
+so you can check if an error occurred by checking whether the first argument is truthy. If there is no error, you should have your `Buffer` object as the second argument. As with `readFile()`, you can supply 'utf8' as the second argument and put the callback as the third argument and you will get a `String` instead of a `Buffer`.
 
 Documentation on the `fs` module can be found by pointing your browser here:
   {rootdir:/node_apidoc/fs.html}


### PR DESCRIPTION
the readFile() can have callback not readFileSync(), it can only have options. ref : https://nodejs.org/api/fs.html#fs_fs_readfilesync_path_options