### PR TITLE
:bug: fixes error in windows when execute npm run test

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "scripts": {
     "lint": "./node_modules/.bin/standard",
-    "test": "npm run lint && ./node_modules/.bin/workshopper-adventure-test",
+    "test": "npm run lint && \"./node_modules/.bin/workshopper-adventure-test\"",
     "release": "./node_modules/.bin/standard-version"
   },
   "bin": {


### PR DESCRIPTION
this fixes an issue where `npm run test` will cause an error in windows machine.


```
npm WARN invalid config loglevel="notice"

> learnyounode@3.5.10 lint C:\Projects\learnyounode
> standard

''.' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! learnyounode@3.5.10 test: `npm run lint && './node_modules/.bin/workshopper-adventure-test'`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the learnyounode@3.5.10 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\chris\AppData\Roaming\npm-cache\_logs\2017-10-05T12_41_41_945Z-debug.log
```