### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 ![Learn You The Node.js For Much Win!](https://raw.github.com/rvagg/learnyounode/master/learnyounode.png)
 
   1. Install [Node.js](http://nodejs.org/)
-  2. Run `npm install learnyounode -g`
+  2. Run `npm install -g learnyounode`
     1. In case it fails, easiest way is to prefix with `sudo`:
 
-        `sudo npm install learnyounode -g` or to:
+        `sudo npm install -g learnyounode` or to:
     2. [fix your npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions).
   3. Run `learnyounode`
     1. (Ubuntu users) In case step 3 fails, run `sudo apt-get install nodejs-legacy`


### PR DESCRIPTION
The order of the command to install learnyounode was not working, so I realize that the default way to do that is to put the global command "-g" before "learnyounode". I don't no if this was made on purpose, but for me, someone that is trying to learn by using learnyounode on a local environment, that way was not working.