### PR TITLE
add NAN checking when converting String to Number

### DIFF
--- a/exercises/baby_steps/solution/solution.js
+++ b/exercises/baby_steps/solution/solution.js
@@ -1,7 +1,9 @@
 let result = 0
 
 for (let i = 2; i < process.argv.length; i++) {
-  result += Number(process.argv[i])
+  parsedArg = Number(process.argv[i])
+  if (isNaN(parsedArg)) continue
+  result += parsedArg
 }
 
 console.log(result)


### PR DESCRIPTION
There is no checking for NaN where converting strings to numbers: e.g. node learnyounode.js test this output 7 7fdf 14 65 will return NaN as result.