### PR TITLE
Recommend run-parallel instead of async functions

### DIFF
--- a/exercises/juggling_async/problem.es.md
+++ b/exercises/juggling_async/problem.es.md
@@ -9,4 +9,4 @@ Como las llamadas a las URLs son asíncronas, es probable que no recibas las res
 
 Tendrás que encolar los resultados y mantener un contador de cuántas peticiones han sido recibidas de modo que al llegar al final puedas imprimir los resultados.
 
-En la vida real, utilizar [`run-parallel`](https://www.npmjs.com/package/run-parallel) facilitaria la continuación de los callbacks. Pero para el alcance de este ejercicio se debería realizar sin utilizarlo.
+En la vida real, utilizar [`async`](https://www.npmjs.com/package/async) o [`run-parallel`](https://www.npmjs.com/package/run-parallel) facilitaria la continuación de los callbacks. Pero para el alcance de este ejercicio se debería realizar sin utilizarlo.

--- a/exercises/juggling_async/problem.md
+++ b/exercises/juggling_async/problem.md
@@ -11,7 +11,7 @@ Don't expect these three servers to play nicely! They are not going to give you 
 
 You will need to queue the results and keep track of how many of the URLs have returned their entire contents. Only once you have them all, you can print the data to the console.
 
-Counting callbacks is one of the fundamental ways of managing async in Node. Rather than doing it manually, you may find it more convenient to rely on [`run-parallel`](https://www.npmjs.com/package/run-parallel). But for this exercise, do it without that.
+Counting callbacks is one of the fundamental ways of managing async in Node. Rather than doing it manually, you may find it more convenient to rely on [`async`](https://www.npmjs.com/package/async) or [`run-parallel`](https://www.npmjs.com/package/run-parallel). But for this exercise, do it without that.
 
 Check to see if your program is correct by running this command:
 


### PR DESCRIPTION
We're not recommending promise versions of node core modules in these exercies yet, so telling newbies to go read about async functions seems like a red herring. I'd rather they use something simple like `run-parallel` which operates on callbacks for now.

cc @ccarruitero