### PR TITLE
fix(make_it_modular): use proxyquire for mock fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "concat-stream": "^2.0.0",
     "duplexer": "^0.1.1",
     "hyperquest": "^2.1.3",
+    "proxyquire": "^2.1.3",
     "rimraf": "^3.0.0",
     "through2": "^3.0.1",
     "through2-map": "^3.0.0",

--- a/test/make_it_modular/module_valid_03.js
+++ b/test/make_it_modular/module_valid_03.js
@@ -1,0 +1,13 @@
+const { readdir } = require('fs')
+const { extname } = require('path')
+
+module.exports = (directory, extension, callback) => {
+  const isExtension = (file) => extname(file) === `.${extension}`
+
+  readdir(directory, (err, files) => {
+    if (err) return callback(err)
+
+    const matchingFiles = files.filter(isExtension)
+    callback(null, matchingFiles)
+  })
+}

--- a/test/make_it_modular/valid_03.js
+++ b/test/make_it_modular/valid_03.js
@@ -1,0 +1,9 @@
+const mod = require('./module_valid_03')
+
+mod(process.argv[2], process.argv[3], (error, list) => {
+  if (error) return console.log(error)
+
+  list.forEach((entry) => {
+    console.log(entry)
+  })
+})


### PR DESCRIPTION
This fix verification when use destructuring assignment for fs.

fix #700 